### PR TITLE
Fix API docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Node.js client library for accessing the Spotinst API.
 
-You can view Spotinst API docs [here](http://help.spotinst.com/api/).
+You can view Spotinst API docs [here](https://api.spotinst.com/).
 
 ## Installation
 
@@ -89,7 +89,7 @@ client.AwsGroupService.read({id: 'sig-bar'}, (err, groups) => {
 
 ## Documentation
 
-For a comprehensive list of examples, check out the [API documentation](http://help.spotinst.com/api/).
+For a comprehensive list of examples, check out the [API documentation](https://api.spotinst.com/).
 
 ## Contributing
 


### PR DESCRIPTION
The current link took me to a 404, which linked to a relative URL instead of an absolute one, which also didn't work as an absolute one. You may want to fix all that as well.